### PR TITLE
Update Repository Organization name for LibertyDSNP/frequency

### DIFF
--- a/data/repository.json
+++ b/data/repository.json
@@ -259,7 +259,7 @@
       "project": "Frequency",
       "name": "Frequency",
       "emoji": "📈",
-      "repository_url": "https://github.com/LibertyDSNP/frequency",
+      "repository_url": "https://github.com/frequency-chain/frequency",
       "interests": [
         "data",
         "substrate",

--- a/data/repository_full.json
+++ b/data/repository_full.json
@@ -600,14 +600,14 @@
       "project": "Frequency",
       "name": "Frequency",
       "emoji": "📈",
-      "repository_url": "https://github.com/LibertyDSNP/frequency",
+      "repository_url": "https://github.com/frequency-chain/frequency",
       "interests": [
         "data",
         "substrate",
         "oracles"
       ],
       "id": "2f813d2a-6546-448e-b749-6cb10c8b4684",
-      "value": "LibertyDSNP/frequency",
+      "value": "frequency-chain/frequency",
       "topics": [
         "blockchain",
         "parachain",


### PR DESCRIPTION
The org name was changed: LibertyDSNP/frequency -> frequency-chain/frequency

https://github.com/frequency-chain/frequency